### PR TITLE
fix: remove unnecessary await when reading cookies

### DIFF
--- a/src/app/api/auth/mercadolibre/callback/route.ts
+++ b/src/app/api/auth/mercadolibre/callback/route.ts
@@ -8,7 +8,7 @@ const prisma = new PrismaClient();
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const code = searchParams.get('code');
-  const cookieStore = await cookies();
+  const cookieStore = cookies();
   const codeVerifier = cookieStore.get('pkce_code_verifier')?.value;
   const sessionToken = cookieStore.get('session_token')?.value;
 

--- a/src/app/api/auth/mercadolibre/disconnect/route.ts
+++ b/src/app/api/auth/mercadolibre/disconnect/route.ts
@@ -7,7 +7,7 @@ const prisma = new PrismaClient();
 
 export async function POST() {
   try {
-    const cookieStore = await cookies();
+    const cookieStore = cookies();
     const sessionToken = cookieStore.get('session_token')?.value;
 
     if (!sessionToken) {

--- a/src/app/api/customers/route.ts
+++ b/src/app/api/customers/route.ts
@@ -55,7 +55,7 @@ async function getValidAccessToken(userId: string) {
 // --- API PRINCIPAL PARA OBTENER CLIENTES ---
 export async function GET() {
   try {
-    const cookieStore = await cookies();
+    const cookieStore = cookies();
     const sessionToken = cookieStore.get('session_token')?.value;
 
     if (!sessionToken) return NextResponse.json({ message: 'No autenticado' }, { status: 401 });

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -9,7 +9,7 @@ const prisma = new PrismaClient();
 export async function GET() {
   try {
     // Obtener el token de sesión
-    const cookieStore = await cookies();
+    const cookieStore = cookies();
     const sessionToken = cookieStore.get('session_token')?.value;
 
     if (!sessionToken) {


### PR DESCRIPTION
## Summary
- avoid awaiting synchronous cookies() in API routes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type.)*

------
https://chatgpt.com/codex/tasks/task_e_6893fa3664c8832ea55b49b15fcc80f0