### PR TITLE
feat: expose MercadoLibre tokens for current user

### DIFF
--- a/src/app/api/auth/mercadolibre/token/route.ts
+++ b/src/app/api/auth/mercadolibre/token/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import { jwtVerify } from 'jose';
+import { cookies } from 'next/headers';
+
+const prisma = new PrismaClient();
+
+export async function GET() {
+  try {
+    const cookieStore = await cookies();
+    const sessionToken = cookieStore.get('session_token')?.value;
+    if (!sessionToken) {
+      return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+    }
+
+    const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+    const { payload } = await jwtVerify(sessionToken, secret);
+    const userId = payload.userId as string;
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        mercadolibreAccessToken: true,
+        mercadolibreRefreshToken: true,
+        mercadolibreTokenExpiresAt: true,
+      },
+    });
+
+    if (!user || !user.mercadolibreAccessToken || !user.mercadolibreRefreshToken) {
+      return NextResponse.json({ error: 'MercadoLibre no está conectado' }, { status: 400 });
+    }
+
+    return NextResponse.json({
+      accessToken: user.mercadolibreAccessToken,
+      refreshToken: user.mercadolibreRefreshToken,
+      expiresAt: user.mercadolibreTokenExpiresAt,
+    });
+  } catch (error) {
+    console.error('Error obteniendo tokens de MercadoLibre:', error);
+    return NextResponse.json({ error: 'Error del servidor' }, { status: 500 });
+  } finally {
+    await prisma.$disconnect();
+  }
+}


### PR DESCRIPTION
## Summary
- add API endpoint to return MercadoLibre access and refresh tokens for authenticated user

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689494557ea0832eb3012bf5ed3ed09f