### PR TITLE
Fix MercadoLibre token route JWT parsing

### DIFF
--- a/src/app/api/auth/mercadolibre/token/route.ts
+++ b/src/app/api/auth/mercadolibre/token/route.ts
@@ -9,16 +9,30 @@ const prisma = new PrismaClient();
 
 export async function GET() {
   try {
-    const cookieStore = await cookies(); // ✅ corregido
-    const sessionToken = cookieStore.get('session_token')?.value;
+    const cookieStore = cookies();
+    let sessionToken = cookieStore.get('session_token')?.value;
 
     if (!sessionToken) {
       return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
     }
 
+    // Cuando el encabezado `Cookie` trae el token repetido varias veces,
+    // nos quedamos solo con la primera ocurrencia para obtener un JWT válido.
+    const tokenParts = sessionToken.split('.');
+    if (tokenParts.length > 3) {
+      sessionToken = tokenParts.slice(0, 3).join('.');
+    }
+
     const secret = new TextEncoder().encode(process.env.JWT_SECRET);
     console.log("🔐 JWT_SECRET:", process.env.JWT_SECRET);
-    const { payload } = await jwtVerify(sessionToken, secret);
+
+    let payload;
+    try {
+      ({ payload } = await jwtVerify(sessionToken, secret));
+    } catch {
+      return NextResponse.json({ error: 'Token inválido' }, { status: 401 });
+    }
+
     const userId = payload.userId as string;
 
     const user = await prisma.user.findUnique({


### PR DESCRIPTION
## Summary
- handle duplicated JWT segments in `session_token` cookie
- return 401 for invalid tokens before querying DB

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894b0590cac832ea1ce4054932ea27f