### PR TITLE
fix: include post-sale tag for MercadoLibre messages

### DIFF
--- a/src/app/api/customers/[id]/message/route.ts
+++ b/src/app/api/customers/[id]/message/route.ts
@@ -74,7 +74,7 @@ export async function POST(
     const user = await prisma.user.findUnique({ where: { id: userId } });
 
     const mlResponse = await fetch(
-      `https://api.mercadolibre.com/messages/packs/${orderId}/sellers/${user?.mercadolibreId}`,
+      `https://api.mercadolibre.com/messages/packs/${orderId}/sellers/${user?.mercadolibreId}?tag=post_sale`,
       {
         method: 'POST',
         headers: {


### PR DESCRIPTION
## Summary
- add required `post_sale` tag to MercadoLibre message endpoint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dbe20a368832e8ebca0b91c4d531d