### PR TITLE
feat: add customer filters and bulk messaging

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 
 // --- Funciones para PKCE ---
 function base64URLEncode(str: Buffer) {
@@ -48,8 +48,21 @@ interface Customer {
   lastName?: string | null;
   purchaseCount: number;
   lastOrderId?: string | null;
+  lastShippingMethod?: string | null;
+  province?: string | null;
 }
 
+const shippingOptions = [
+  { value: 'me2', label: 'Mercado Envíos' },
+  { value: 'me1', label: 'Flex' },
+  { value: 'custom', label: 'Arreglo con el vendedor' },
+  { value: 'correo', label: 'Correo' },
+];
+
+const getShippingLabel = (code?: string | null) => {
+  const option = shippingOptions.find((o) => o.value === code);
+  return option ? option.label : code || 'N/A';
+};
 
 export default function DashboardPage() {
   const router = useRouter();
@@ -57,9 +70,34 @@ export default function DashboardPage() {
   const [loading, setLoading] = useState(true);
   const [customers, setCustomers] = useState<Customer[]>([]);
   const [customersLoading, setCustomersLoading] = useState(true);
-  const [minPurchases, setMinPurchases] = useState(0);
+  const [purchaseFilter, setPurchaseFilter] = useState('');
+  const [provinceFilter, setProvinceFilter] = useState('');
+  const [shippingFilter, setShippingFilter] = useState('');
   const appId = process.env.NEXT_PUBLIC_MERCADOLIBRE_APP_ID;
   const redirectUri = process.env.NEXT_PUBLIC_MERCADOLIBRE_REDIRECT_URI;
+  const provinceOptions = useMemo(() => {
+    const set = new Set<string>();
+    customers.forEach((c) => {
+      if (c.province) set.add(c.province);
+    });
+    return Array.from(set).sort();
+  }, [customers]);
+
+  const filteredCustomers = useMemo(() => {
+    return customers.filter((c) => {
+      let match = true;
+      if (purchaseFilter === '1') match = match && c.purchaseCount === 1;
+      else if (purchaseFilter === '1-5')
+        match = match && c.purchaseCount > 1 && c.purchaseCount <= 5;
+      else if (purchaseFilter === '5-10')
+        match = match && c.purchaseCount > 5 && c.purchaseCount <= 10;
+      else if (purchaseFilter === '10+')
+        match = match && c.purchaseCount > 10;
+      if (provinceFilter) match = match && c.province === provinceFilter;
+      if (shippingFilter) match = match && c.lastShippingMethod === shippingFilter;
+      return match;
+    });
+  }, [customers, purchaseFilter, provinceFilter, shippingFilter]);
 
   // Cargar perfil del usuario al montar el componente
   useEffect(() => {
@@ -139,6 +177,35 @@ export default function DashboardPage() {
     } catch (error) {
       console.error('Error:', error);
       alert('No se pudo enviar el mensaje');
+    }
+  };
+
+  const handleSendMessageAll = async () => {
+    if (filteredCustomers.length === 0) {
+      alert('No hay compradores para enviar mensajes.');
+      return;
+    }
+    const message = prompt('Escribe tu mensaje para todos los compradores:');
+    if (!message) return;
+    try {
+      const responses = await Promise.all(
+        filteredCustomers.map((customer) =>
+          fetch(`/api/customers/${customer.id}/message`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message, orderId: customer.lastOrderId }),
+          })
+        )
+      );
+      const failed = responses.filter((r) => !r.ok);
+      if (failed.length > 0) {
+        alert(`Mensajes enviados con ${failed.length} errores.`);
+      } else {
+        alert('Mensajes enviados');
+      }
+    } catch (error) {
+      console.error('Error enviando mensajes:', error);
+      alert('No se pudieron enviar los mensajes');
     }
   };
 
@@ -309,22 +376,61 @@ export default function DashboardPage() {
         {/* Listado de compradores */}
         <div className="bg-white rounded-lg shadow-md p-6 mb-6">
           <h2 className="text-xl font-semibold text-gray-900 mb-4">Compradores</h2>
-          <div className="flex items-center mb-4">
-            <label className="mr-2 text-sm text-gray-700">Filtrar por compras:</label>
-            <select
-              value={minPurchases}
-              onChange={(e) => setMinPurchases(Number(e.target.value))}
-              className="border rounded px-2 py-1 text-sm"
+          <div className="flex flex-wrap items-center mb-4 gap-4">
+            <div className="flex items-center">
+              <label className="mr-2 text-sm text-gray-700">Compras:</label>
+              <select
+                value={purchaseFilter}
+                onChange={(e) => setPurchaseFilter(e.target.value)}
+                className="border rounded px-2 py-1 text-sm"
+              >
+                <option value="">Todas</option>
+                <option value="1">1 compra</option>
+                <option value="1-5">Entre 1 y 5</option>
+                <option value="5-10">Entre 5 y 10</option>
+                <option value="10+">Más de 10</option>
+              </select>
+            </div>
+            <div className="flex items-center">
+              <label className="mr-2 text-sm text-gray-700">Ubicación:</label>
+              <select
+                value={provinceFilter}
+                onChange={(e) => setProvinceFilter(e.target.value)}
+                className="border rounded px-2 py-1 text-sm"
+              >
+                <option value="">Todas</option>
+                {provinceOptions.map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex items-center">
+              <label className="mr-2 text-sm text-gray-700">Envío:</label>
+              <select
+                value={shippingFilter}
+                onChange={(e) => setShippingFilter(e.target.value)}
+                className="border rounded px-2 py-1 text-sm"
+              >
+                <option value="">Todos</option>
+                {shippingOptions.map((s) => (
+                  <option key={s.value} value={s.value}>
+                    {s.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <button
+              onClick={handleSendMessageAll}
+              className="ml-auto rounded bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-700"
             >
-              <option value={0}>Todos</option>
-              <option value={1}>Más de 1</option>
-              <option value={5}>Más de 5</option>
-              <option value={10}>Más de 10</option>
-            </select>
+              Enviar mensaje a todos
+            </button>
           </div>
           {customersLoading ? (
             <p className="text-gray-600">Cargando...</p>
-          ) : customers.length > 0 ? (
+          ) : filteredCustomers.length > 0 ? (
             <div className="overflow-x-auto">
               <table className="min-w-full divide-y divide-gray-200">
                 <thead className="bg-gray-50">
@@ -332,14 +438,14 @@ export default function DashboardPage() {
                       <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">ID</th>
                       <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">Nickname</th>
                       <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">Nombre</th>
+                      <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">Provincia</th>
+                      <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">Envío</th>
                       <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">Compras</th>
                       <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">Acciones</th>
                     </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-200">
-                  {customers
-                    .filter((c) => c.purchaseCount > minPurchases)
-                    .map((customer) => (
+                  {filteredCustomers.map((customer) => (
                         <tr key={customer.id} className="hover:bg-gray-50">
                           <td className="px-4 py-2 text-sm text-gray-900">{customer.mercadolibreId}</td>
                           <td className="px-4 py-2 text-sm text-gray-900">{customer.nickname}</td>
@@ -348,6 +454,8 @@ export default function DashboardPage() {
                               ? `${customer.firstName ?? ''} ${customer.lastName ?? ''}`.trim()
                               : 'N/A'}
                           </td>
+                          <td className="px-4 py-2 text-sm text-gray-900">{customer.province || 'N/A'}</td>
+                          <td className="px-4 py-2 text-sm text-gray-900">{getShippingLabel(customer.lastShippingMethod)}</td>
                           <td className="px-4 py-2 text-sm text-gray-900">{customer.purchaseCount}</td>
                           <td className="px-4 py-2 text-sm">
                             <button

--- a/src/app/api/customers/route.ts
+++ b/src/app/api/customers/route.ts
@@ -76,10 +76,16 @@ export async function GET() {
 
     const { results: orders } = await ordersResponse.json();
 
-    // Mapa para llevar la cuenta de compras y última orden por comprador
+    // Mapa para llevar la cuenta de compras, ubicación y último envío por comprador
     const buyerStats = new Map<
       string,
-      { count: number; lastOrderId: string; lastOrderDate: string }
+      {
+        count: number;
+        lastOrderId: string;
+        lastOrderDate: string;
+        lastShippingMethod?: string | null;
+        lastProvince?: string | null;
+      }
     >();
 
     interface BuyerDetails {
@@ -101,14 +107,31 @@ export async function GET() {
         continue;
       }
 
-      // Obtener detalles adicionales del comprador si faltan datos
       let firstName = buyer.first_name || null;
       let lastName = buyer.last_name || null;
       let email = buyer.email || null;
 
-      if (!firstName || !lastName || !email) {
+      let shipping = order.shipping;
+      let shippingMethod =
+        shipping?.shipping_mode ??
+        shipping?.mode ??
+        shipping?.logistic_type ??
+        null;
+      let province =
+        shipping?.receiver_address?.state?.name ??
+        shipping?.receiver_address?.state ??
+        null;
+
+      if (
+        !firstName ||
+        !lastName ||
+        !email ||
+        !shipping ||
+        !shippingMethod ||
+        !province
+      ) {
         let details = buyerDetailsCache.get(buyer.id);
-        if (!details) {
+        if (!details || !shipping || !shippingMethod || !province) {
           const orderDetailsResponse = await fetch(
             `https://api.mercadolibre.com/orders/${order.id}`,
             {
@@ -122,33 +145,73 @@ export async function GET() {
               last_name: orderDetails.buyer?.last_name,
               email: orderDetails.buyer?.email,
             } as BuyerDetails;
+            shipping = orderDetails.shipping;
             buyerDetailsCache.set(buyer.id, details);
           }
         }
         firstName = firstName || details?.first_name || null;
         lastName = lastName || details?.last_name || null;
         email = email || details?.email || null;
+        shippingMethod =
+          shippingMethod ||
+          shipping?.shipping_mode ||
+          shipping?.mode ||
+          shipping?.logistic_type ||
+          null;
+        province =
+          province ||
+          shipping?.receiver_address?.state?.name ||
+          shipping?.receiver_address?.state ||
+          null;
       }
 
-      // Convertir el ID a BigInt para que coincida con el esquema
       const buyerIdBigInt = BigInt(buyer.id);
 
-      // Actualizar estadísticas de compras
       const buyerIdStr = buyer.id.toString();
       const currentStats = buyerStats.get(buyerIdStr);
       const orderDate = order.date_created;
       const packId = (order.pack_id ?? order.id).toString();
+      if ((!shippingMethod || !province) && shipping?.id) {
+        try {
+          const shippingRes = await fetch(
+            `https://api.mercadolibre.com/shipments/${shipping.id}`,
+            {
+              headers: { Authorization: `Bearer ${accessToken}` },
+            }
+          );
+          if (shippingRes.ok) {
+            const shippingDetails = await shippingRes.json();
+            shippingMethod =
+              shippingMethod ||
+              shippingDetails.shipping_mode ||
+              shippingDetails.mode ||
+              shippingDetails.logistic_type ||
+              null;
+            province =
+              province ||
+              shippingDetails.receiver_address?.state?.name ||
+              shippingDetails.receiver_address?.state ||
+              null;
+          }
+        } catch (err) {
+          console.error('Error obteniendo envío', order.id, err);
+        }
+      }
       if (currentStats) {
         currentStats.count += 1;
         if (new Date(orderDate) > new Date(currentStats.lastOrderDate)) {
           currentStats.lastOrderId = packId;
           currentStats.lastOrderDate = orderDate;
+          currentStats.lastShippingMethod = shippingMethod;
+          currentStats.lastProvince = province;
         }
       } else {
         buyerStats.set(buyerIdStr, {
           count: 1,
           lastOrderId: packId,
           lastOrderDate: orderDate,
+          lastShippingMethod: shippingMethod,
+          lastProvince: province,
         });
       }
 
@@ -184,6 +247,8 @@ export async function GET() {
         mercadolibreId: c.mercadolibreId.toString(),
         purchaseCount: stats?.count || 0,
         lastOrderId: stats?.lastOrderId || null,
+        lastShippingMethod: stats?.lastShippingMethod || null,
+        province: stats?.lastProvince || null,
       };
     });
 


### PR DESCRIPTION
## Summary
- expand customer API to track province and shipping method
- add combined filters and bulk message action on dashboard
- load shipping data from orders and limit province filter to populated locations
- send bulk messages concurrently for better performance

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dc31b690c832eaaad417dc3cae37f