### PR TITLE
fix: authenticate product detail requests

### DIFF
--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -55,7 +55,10 @@ export async function GET() {
     }
 
     const detailsRes = await fetch(
-      `https://api.mercadolibre.com/items?ids=${ids.join(',')}`
+      `https://api.mercadolibre.com/items?ids=${ids.join(',')}`,
+      {
+        headers: { Authorization: `Bearer ${user.mercadolibreAccessToken}` },
+      }
     );
 
     if (!detailsRes.ok) {


### PR DESCRIPTION
## Summary
- add authorization header when requesting product details from MercadoLibre

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a10e97c2e0832e9113b372f3c3397a