### PR TITLE
Apply discount to MercadoLibre item and include link in promotion messages

### DIFF
--- a/src/app/api/promotions/route.ts
+++ b/src/app/api/promotions/route.ts
@@ -71,6 +71,18 @@ export async function POST(request: Request) {
     const productRes = await fetch(`https://api.mercadolibre.com/items/${productId}`);
     const productData = await productRes.json();
     const productTitle = productData?.title ?? 'nuestro producto';
+    const productLink = productData?.permalink ?? '';
+    const originalPrice = Number(productData?.price ?? 0);
+    const discountedPrice = Math.round(originalPrice * (1 - discount / 100) * 100) / 100;
+
+    await fetch(`https://api.mercadolibre.com/items/${productId}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ price: discountedPrice }),
+    });
 
     const promotionsSent: { customerId: string }[] = [];
 
@@ -85,7 +97,7 @@ export async function POST(request: Request) {
 
       if (!lastOrder) continue;
 
-      const message = `¡Hola! Te ofrecemos un ${discount}% de descuento en nuestro producto ${productTitle}.`;
+      const message = `¡Hola! Te ofrecemos un ${discount}% de descuento en nuestro producto ${productTitle}. Aprovecha la oferta aquí: ${productLink}`;
 
       try {
         await fetch(


### PR DESCRIPTION
## Summary
- update promotion API to apply discounted price on selected MercadoLibre listing
- include product permalink with discount in messages sent to recent buyers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a139a9077c832ea8d0f3ae805b4125