### PR TITLE
Improve promotion error reporting

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -247,8 +247,14 @@ export default function DashboardPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       });
+      let result: { promotionsSent?: unknown; message?: string } = {};
+      try {
+        result = await response.json();
+      } catch {
+        result = {};
+      }
+
       if (response.ok) {
-        const result = await response.json();
         const sentCount = Array.isArray(result.promotionsSent) ? result.promotionsSent.length : 0;
         if (sentCount > 0) {
           alert(`Promociones enviadas a ${sentCount} clientes`);
@@ -256,10 +262,10 @@ export default function DashboardPage() {
           setSelectedProductId('');
           setPromotionDiscount('');
         } else {
-          alert('No se pudieron enviar las promociones');
+          alert(result.message || 'No se pudieron enviar las promociones');
         }
       } else {
-        alert('No se pudieron enviar las promociones');
+        alert(result.message || 'No se pudieron enviar las promociones');
       }
     } catch (error) {
       console.error('Error enviando promociones:', error);

--- a/src/app/api/promotions/route.ts
+++ b/src/app/api/promotions/route.ts
@@ -129,6 +129,9 @@ export async function POST(request: Request) {
 
       promotionsSent.push({ customerId: customer.id });
     }
+    if (promotionsSent.length === 0) {
+      return NextResponse.json({ message: 'No se pudieron enviar las promociones' }, { status: 500 });
+    }
 
     return NextResponse.json({ success: true, promotionsSent }, { status: 200 });
   } catch (error) {


### PR DESCRIPTION
## Summary
- Return an error when no promotions are sent
- Surface backend error messages in the dashboard when sending promotions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a13f8ae97c832e8c8f0d50aae2b94f