### PR TITLE
fix: avoid 500 when no promotions sent

### DIFF
--- a/src/app/api/promotions/route.ts
+++ b/src/app/api/promotions/route.ts
@@ -130,7 +130,10 @@ export async function POST(request: Request) {
       promotionsSent.push({ customerId: customer.id });
     }
     if (promotionsSent.length === 0) {
-      return NextResponse.json({ message: 'No se pudieron enviar las promociones' }, { status: 500 });
+      return NextResponse.json(
+        { success: false, message: 'No se pudieron enviar las promociones', promotionsSent },
+        { status: 200 }
+      );
     }
 
     return NextResponse.json({ success: true, promotionsSent }, { status: 200 });


### PR DESCRIPTION
## Summary
- return success false instead of 500 error when no promotions sent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1415a41d4832e844c12623e4d5705