### PR TITLE
Add product promotion management

### DIFF
--- a/src/app/api/products/[id]/promotion/route.ts
+++ b/src/app/api/products/[id]/promotion/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import { jwtVerify } from 'jose';
+import { cookies } from 'next/headers';
+
+const prisma = new PrismaClient();
+
+async function getValidAccessToken(userId: string) {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+
+  if (!user || !user.mercadolibreRefreshToken || !user.mercadolibreTokenExpiresAt) {
+    throw new Error('Usuario no conectado a Mercado Libre.');
+  }
+
+  if (new Date() > new Date(user.mercadolibreTokenExpiresAt.getTime() - 5 * 60 * 1000)) {
+    const tokenResponse = await fetch('https://api.mercadolibre.com/oauth/token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: process.env.MERCADOLIBRE_APP_ID!,
+        client_secret: process.env.MERCADOLIBRE_SECRET_KEY!,
+        refresh_token: user.mercadolibreRefreshToken,
+      }),
+    });
+
+    if (!tokenResponse.ok) throw new Error('No se pudo refrescar el token de Mercado Libre.');
+
+    const newTokens = await tokenResponse.json();
+    const expiresAt = new Date(Date.now() + newTokens.expires_in * 1000);
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: {
+        mercadolibreAccessToken: newTokens.access_token,
+        mercadolibreRefreshToken: newTokens.refresh_token,
+        mercadolibreTokenExpiresAt: expiresAt,
+      },
+    });
+
+    return newTokens.access_token;
+  }
+
+  return user.mercadolibreAccessToken;
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const cookieStore = await cookies();
+    const sessionToken = cookieStore.get('session_token')?.value;
+    if (!sessionToken) {
+      return NextResponse.json({ message: 'No autenticado' }, { status: 401 });
+    }
+
+    const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+    const { payload } = await jwtVerify(sessionToken, secret);
+    const userId = payload.userId as string;
+
+    const { discount } = await request.json();
+    if (!discount || typeof discount !== 'number') {
+      return NextResponse.json({ message: 'Descuento inválido' }, { status: 400 });
+    }
+
+    const accessToken = await getValidAccessToken(userId);
+
+    const productRes = await fetch(`https://api.mercadolibre.com/items/${params.id}`);
+    if (!productRes.ok) {
+      return NextResponse.json(
+        { message: 'Producto no encontrado' },
+        { status: productRes.status }
+      );
+    }
+    const productData = await productRes.json();
+    const originalPrice = Number(productData?.price ?? 0);
+    const permalink = productData?.permalink ?? '';
+    const discountedPrice = Math.round(originalPrice * (1 - discount / 100) * 100) / 100;
+
+    const updateRes = await fetch(`https://api.mercadolibre.com/items/${params.id}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({ price: discountedPrice }),
+    });
+
+    if (!updateRes.ok) {
+      return NextResponse.json(
+        { message: 'No se pudo aplicar la promoción' },
+        { status: updateRes.status }
+      );
+    }
+
+    return NextResponse.json({ success: true, permalink }, { status: 200 });
+  } catch (error) {
+    console.error('Error setting promotion:', error);
+    return NextResponse.json({ message: 'Error en el servidor' }, { status: 500 });
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+


### PR DESCRIPTION
## Summary
- enable products to be set on promotion via MercadoLibre API
- allow copying the product purchase link after applying a promotion

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a142c9c020832e8d1109fb13fa2c79