### PR TITLE
fix: include authorization when verifying product for promotion

### DIFF
--- a/src/app/api/products/[id]/promotion/route.ts
+++ b/src/app/api/products/[id]/promotion/route.ts
@@ -69,7 +69,12 @@ export async function POST(
 
     const accessToken = await getValidAccessToken(userId);
     const { id } = await params;
-    const productRes = await fetch(`https://api.mercadolibre.com/items/${id}`);
+    const productRes = await fetch(`https://api.mercadolibre.com/items/${id}` , {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/json',
+      },
+    });
     if (!productRes.ok) {
       return NextResponse.json(
         { message: 'Producto no encontrado' },


### PR DESCRIPTION
## Summary
- include authorization header when fetching product info to apply promotion

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a22471e570832eae166ccb1cbe25d8