### PR TITLE
Use Mercado Libre promotion API and surface promotion details

### DIFF
--- a/prisma/migrations/20250817185951_add_promotion_fields/migration.sql
+++ b/prisma/migrations/20250817185951_add_promotion_fields/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "Product" ADD COLUMN "promotionId" TEXT;
+ALTER TABLE "Product" ADD COLUMN "promotionExpiresAt" TIMESTAMP(3);
+ALTER TABLE "Product" ADD COLUMN "promotionLink" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Product_promotionId_key" ON "Product"("promotionId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,9 @@ model Product {
   userId    String
   orders    Order[]
   user      User     @relation(fields: [userId], references: [id])
+  promotionId       String?   @unique
+  promotionExpiresAt DateTime?
+  promotionLink     String?
 }
 
 model Order {


### PR DESCRIPTION
## Summary
- switch to Mercado Libre seller-promotions API instead of changing item price directly
- persist promotion id, expiration and link on products
- show promotion link and expiry in dashboard

## Testing
- `npx prisma generate`
- `npm test`
- `npm run lint`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db npx prisma migrate dev --name add_promotion_fields --create-only` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68a2260a9528832ea79f1a69aed9baf2