### PR TITLE
Include marketplace and price in promotion payload

### DIFF
--- a/src/app/api/products/[id]/promotion/route.ts
+++ b/src/app/api/products/[id]/promotion/route.ts
@@ -87,14 +87,16 @@ export async function POST(
     const productData = await productRes.json();
     const permalink = productData?.permalink ?? '';
     const originalPrice = Number(productData?.price ?? 0);
+    const marketplaceId = productData?.site_id || 'MLA';
 
     const promotionPayload = {
       type: 'custom',
+      marketplace_id: marketplaceId,
       value_type: 'PERCENTAGE',
       value: discount,
       start_date: new Date().toISOString(),
       finish_date: new Date(expiresAt).toISOString(),
-      items: [{ id }],
+      items: [{ id, price: originalPrice }],
     };
 
     const promoRes = await fetch(

--- a/src/app/api/promotions/route.ts
+++ b/src/app/api/promotions/route.ts
@@ -79,14 +79,16 @@ export async function POST(request: Request) {
     const productTitle = productData?.title ?? 'nuestro producto';
     const productLink = productData?.permalink ?? '';
     const originalPrice = Number(productData?.price ?? 0);
+    const marketplaceId = productData?.site_id || 'MLA';
 
     const promotionPayload = {
       type: 'custom',
+      marketplace_id: marketplaceId,
       value_type: 'PERCENTAGE',
       value: discount,
       start_date: new Date().toISOString(),
       finish_date: new Date(expiresAt).toISOString(),
-      items: [{ id: productId }],
+      items: [{ id: productId, price: originalPrice }],
     };
 
     const promoRes = await fetch(


### PR DESCRIPTION
## Summary
- include marketplace ID and price when creating seller promotions
- ensure promotion API sends required item price

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a227b85940832e8f3add06766ffef6