### PR TITLE
Fix promotion payload and callback POST handler

### DIFF
--- a/src/app/api/auth/mercadolibre/callback/route.ts
+++ b/src/app/api/auth/mercadolibre/callback/route.ts
@@ -110,3 +110,7 @@ export async function GET(request: Request) {
     await prisma.$disconnect();
   }
 }
+
+export async function POST(request: Request) {
+  return GET(request);
+}

--- a/src/app/api/promotions/route.ts
+++ b/src/app/api/promotions/route.ts
@@ -86,12 +86,11 @@ export async function POST(request: Request) {
     const promotionPayload = {
       type: 'custom',
       site_id: marketplaceId,
-      marketplace_id: marketplaceId,
       value_type: 'PERCENTAGE',
       value: discount,
       start_date: new Date().toISOString(),
       finish_date: new Date(expiresAt).toISOString(),
-      items: [{ id: productId, price: originalPrice, currency_id: currencyId }],
+      items: [{ item_id: productId, price: originalPrice, currency_id: currencyId }],
     };
 
     const promoRes = await fetch(
@@ -107,8 +106,20 @@ export async function POST(request: Request) {
       }
     );
     if (!promoRes.ok) {
+      let details: string | undefined;
+      try {
+        const errorJson = await promoRes.json();
+        details = JSON.stringify(errorJson);
+      } catch {
+        try {
+          details = await promoRes.text();
+        } catch {
+          details = undefined;
+        }
+      }
+      console.error('Mercado Libre promotion error:', promoRes.status, details);
       return NextResponse.json(
-        { message: 'No se pudo aplicar la promoción' },
+        { message: 'No se pudo aplicar la promoción', details },
         { status: promoRes.status }
       );
     }


### PR DESCRIPTION
## Summary
- ensure promotion requests send `item_id` and log Mercado Libre errors
- handle POST requests on MercadoLibre OAuth callback by delegating to GET handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a22b35c2e0832eaddef4ba00f15d7c