### PR TITLE
Fix promotion payload with discounted price

### DIFF
--- a/src/app/api/products/[id]/promotion/route.ts
+++ b/src/app/api/products/[id]/promotion/route.ts
@@ -63,7 +63,7 @@ export async function POST(
     const userId = payload.userId as string;
 
     const { discount, expiresAt } = await request.json();
-    if (!discount || typeof discount !== 'number') {
+    if (!discount || typeof discount !== 'number' || discount >= 100 || discount <= 0) {
       return NextResponse.json({ message: 'Descuento inválido' }, { status: 400 });
     }
     if (!expiresAt || isNaN(Date.parse(expiresAt))) {
@@ -90,6 +90,9 @@ export async function POST(
     const marketplaceId = productData?.site_id || 'MLA';
 
     const currencyId = productData?.currency_id || 'ARS';
+    const discountedPrice = Number(
+      (originalPrice * (1 - discount / 100)).toFixed(2)
+    );
 
     const promotionPayload = {
       type: 'custom',
@@ -98,7 +101,7 @@ export async function POST(
       value: discount,
       start_date: new Date().toISOString(),
       finish_date: new Date(expiresAt).toISOString(),
-      items: [{ item_id: id, price: originalPrice, currency_id: currencyId }],
+      items: [{ item_id: id, price: discountedPrice, currency_id: currencyId }],
     };
 
     const promoRes = await fetch(

--- a/src/app/api/promotions/route.ts
+++ b/src/app/api/promotions/route.ts
@@ -68,6 +68,9 @@ export async function POST(request: Request) {
       !Array.isArray(customerIds) ||
       !productId ||
       !discount ||
+      typeof discount !== 'number' ||
+      discount >= 100 ||
+      discount <= 0 ||
       !expiresAt ||
       isNaN(Date.parse(expiresAt))
     ) {
@@ -82,6 +85,9 @@ export async function POST(request: Request) {
     const marketplaceId = productData?.site_id || 'MLA';
 
     const currencyId = productData?.currency_id || 'ARS';
+    const discountedPrice = Number(
+      (originalPrice * (1 - discount / 100)).toFixed(2)
+    );
 
     const promotionPayload = {
       type: 'custom',
@@ -90,7 +96,7 @@ export async function POST(request: Request) {
       value: discount,
       start_date: new Date().toISOString(),
       finish_date: new Date(expiresAt).toISOString(),
-      items: [{ item_id: productId, price: originalPrice, currency_id: currencyId }],
+      items: [{ item_id: productId, price: discountedPrice, currency_id: currencyId }],
     };
 
     const promoRes = await fetch(


### PR DESCRIPTION
## Summary
- validate discount range for MercadoLibre promotions
- send discounted price in promotion payload

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a22d204964832ebe6b8713f7b7c40d