### PR TITLE
Handle promotion API errors on dashboard

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -253,21 +253,27 @@ export default function DashboardPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ discount, expiresAt }),
       });
-      let data: {
-        permalink?: string;
-        promotionId?: string;
-        expiresAt?: string;
-        message?: string;
-      } = {};
-      try {
-        data = await res.json();
-      } catch {
-        data = {};
-      }
-      if (!res.ok) {
-        alert(data.message || 'No se pudo aplicar la promoción');
-        return;
-      }
+        let data: {
+          permalink?: string;
+          promotionId?: string;
+          expiresAt?: string;
+          message?: string;
+          details?: string;
+        } = {};
+        try {
+          data = await res.json();
+        } catch {
+          data = {};
+        }
+        if (!res.ok) {
+          console.error('Promotion request failed:', data);
+          alert(
+            `${data.message || 'No se pudo aplicar la promoción'}${
+              data.details ? `: ${data.details}` : ''
+            }`
+          );
+          return;
+        }
       if (data.permalink && data.promotionId && data.expiresAt) {
         setPromotionData((prev) => ({
           ...prev,


### PR DESCRIPTION
## Summary
- Show API promotion errors on the dashboard page and display backend message/details to user
- Log response JSON for quick debugging

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a23d9fcd58832e8fbbcd27b6fa5de1