### PR TITLE
Fix Mercado Libre promotion API params and app version

### DIFF
--- a/src/app/api/products/[id]/promotion/route.ts
+++ b/src/app/api/products/[id]/promotion/route.ts
@@ -49,7 +49,7 @@ async function getValidAccessToken(userId: string) {
 
 export async function POST(
   request: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     const cookieStore = await cookies();
@@ -71,7 +71,7 @@ export async function POST(
     }
 
     const accessToken = await getValidAccessToken(userId);
-    const { id } = params;
+    const { id } = await params;
     const productRes = await fetch(`https://api.mercadolibre.com/items/${id}` , {
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -105,7 +105,7 @@ export async function POST(
     };
 
     const promoRes = await fetch(
-      'https://api.mercadolibre.com/seller-promotions/promotions',
+      'https://api.mercadolibre.com/seller-promotions/promotions?app_version=1',
       {
         method: 'POST',
         headers: {

--- a/src/app/api/promotions/route.ts
+++ b/src/app/api/promotions/route.ts
@@ -100,7 +100,7 @@ export async function POST(request: Request) {
     };
 
     const promoRes = await fetch(
-      'https://api.mercadolibre.com/seller-promotions/promotions',
+      'https://api.mercadolibre.com/seller-promotions/promotions?app_version=1',
       {
         method: 'POST',
         headers: {


### PR DESCRIPTION
## Summary
- await dynamic route params when applying promotion to a product
- include `app_version` query parameter when calling Mercado Libre promotions API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2465d3334832ebb0fc23de4586e1f