### PR TITLE
fix: call toast hook at top level

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -64,6 +64,8 @@ interface MLProduct {
 
 export default function DashboardPage() {
   const router = useRouter();
+  // Acquire toast context at the top level to comply with React hook rules
+  const { toast } = useToast();
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
   const [customers, setCustomers] = useState<Customer[]>([]);
@@ -82,7 +84,6 @@ export default function DashboardPage() {
   const [disconnectModal, setDisconnectModal] = useState(false);
   const appId = process.env.NEXT_PUBLIC_MERCADOLIBRE_APP_ID;
   const redirectUri = process.env.NEXT_PUBLIC_MERCADOLIBRE_REDIRECT_URI;
-  const { toast } = useToast();
 
   const filteredCustomers = useMemo(() => {
     return customers.filter((c) => {


### PR DESCRIPTION
## Summary
- move useToast to top of DashboardPage to comply with React hook rules
- document toast hook placement

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae06e8c44c832e8f92b93d4b802ce0