### PR TITLE
Add Fiddo branding and toast notifications

### DIFF
--- a/public/fiddo-logo.svg
+++ b/public/fiddo-logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 24">
+  <text x="0" y="20" font-size="20" font-family="sans-serif">
+    <tspan fill="#1e40af">F</tspan>
+    <tspan fill="#f97316">i</tspan>
+    <tspan fill="#14b8a6">ddo</tspan>
+  </text>
+</svg>

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -516,7 +516,7 @@ export default function DashboardPage() {
         <div className="bg-white rounded-lg shadow-md p-6 mb-6">
           <div className="flex justify-between items-center">
             <div>
-              <h1 className="text-3xl font-bold text-fiddo-blue">Fiddo</h1>
+              <Image src="/fiddo-logo.svg" alt="Fiddo" width={100} height={32} />
               <p className="text-gray-600 mt-1">¡Bienvenido, {userProfile?.user.name}!</p>
             </div>
             <button

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,21 +1,22 @@
 // src/app/login/page.tsx
 'use client';
 
+import Image from 'next/image';
 import Link from 'next/link';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useToast } from '@/components/ui/Toast';
 
 export default function LoginPage() {
   const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const { toast } = useToast();
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setIsLoading(true);
-    setError('');
 
     try {
       const response = await fetch('/api/auth/login', {
@@ -35,17 +36,17 @@ export default function LoginPage() {
 
     } catch (error: unknown) {
       console.error('Error al iniciar sesión:', error);
-      setError(error instanceof Error ? error.message : 'Algo salió mal');
+      toast(error instanceof Error ? error.message : 'Algo salió mal');
     } finally {
       setIsLoading(false);
     }
   };
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+    <main className="flex min-h-screen items-center justify-center bg-gradient-to-br from-fiddo-blue via-fiddo-turquoise to-fiddo-orange p-4">
       <div className="w-full max-w-md space-y-8 rounded-xl bg-white p-8 shadow-lg">
         <div className="text-center">
-          <h1 className="text-4xl font-bold text-fiddo-blue">Fiddo</h1>
+          <Image src="/fiddo-logo.svg" alt="Fiddo" width={80} height={24} className="mx-auto" />
           <h2 className="mt-2 text-3xl font-bold tracking-tight text-gray-900">
             Iniciar Sesión
           </h2>
@@ -95,8 +96,6 @@ export default function LoginPage() {
               />
             </div>
           </div>
-
-          {error && <p className="text-sm text-red-600">{error}</p>}
 
           <div>
             <button

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,23 @@
 // src/app/register/page.tsx
 'use client';
 
+import Image from 'next/image';
 import Link from 'next/link';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation'; // Hook para la redirección
+import { useToast } from '@/components/ui/Toast';
 
 export default function RegisterPage() {
   const router = useRouter();
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const { toast } = useToast();
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setIsLoading(true);
-    setError('');
 
     try {
       const response = await fetch('/api/auth/register', {
@@ -35,21 +36,22 @@ export default function RegisterPage() {
 
       // Si el registro es exitoso, redirigir al login
       console.log('Usuario registrado con éxito:', data);
+      toast('Usuario registrado con éxito');
       router.push('/login');
 
     } catch (error: unknown) {
       console.error('Error en el registro:', error);
-      setError(error instanceof Error ? error.message : 'Error en el registro');
+      toast(error instanceof Error ? error.message : 'Error en el registro');
     } finally {
       setIsLoading(false);
     }
   };
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+    <main className="flex min-h-screen items-center justify-center bg-gradient-to-br from-fiddo-blue via-fiddo-turquoise to-fiddo-orange p-4">
       <div className="w-full max-w-md space-y-8 rounded-xl bg-white p-8 shadow-lg">
         <div className="text-center">
-          <h1 className="text-4xl font-bold text-fiddo-blue">Fiddo</h1>
+          <Image src="/fiddo-logo.svg" alt="Fiddo" width={80} height={24} className="mx-auto" />
           <h2 className="mt-2 text-3xl font-bold tracking-tight text-gray-900">
             Crear una Cuenta
           </h2>
@@ -88,8 +90,6 @@ export default function RegisterPage() {
               <input id="password" name="password" type="password" required minLength={8} placeholder="••••••••" value={password} onChange={(e) => setPassword(e.target.value)} className="block w-full appearance-none rounded-md border border-gray-300 px-3 py-2 placeholder-gray-400 shadow-sm focus:border-fiddo-turquoise focus:outline-none focus:ring-fiddo-turquoise sm:text-sm" />
             </div>
           </div>
-          
-          {error && <p className="text-sm text-red-600">{error}</p>}
 
           <div>
             <button type="submit" disabled={isLoading} className="flex w-full justify-center rounded-md border border-transparent bg-fiddo-blue py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-fiddo-turquoise focus:outline-none focus:ring-2 focus:ring-fiddo-turquoise focus:ring-offset-2 disabled:opacity-50">

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,22 +1,23 @@
 // src/app/register/page.tsx
 'use client';
 
+import Image from 'next/image';
 import Link from 'next/link';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation'; // Hook para la redirección
+import { useToast } from '@/components/ui/Toast';
 
 export default function RegisterPage() {
   const router = useRouter();
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const { toast } = useToast();
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setIsLoading(true);
-    setError('');
 
     try {
       const response = await fetch('/api/auth/register', {
@@ -35,21 +36,22 @@ export default function RegisterPage() {
 
       // Si el registro es exitoso, redirigir al login
       console.log('Usuario registrado con éxito:', data);
+      toast('Usuario registrado con éxito');
       router.push('/login');
 
     } catch (error: unknown) {
       console.error('Error en el registro:', error);
-      setError(error instanceof Error ? error.message : 'Error en el registro');
+      toast(error instanceof Error ? error.message : 'Error en el registro');
     } finally {
       setIsLoading(false);
     }
   };
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+    <main className="flex min-h-screen items-center justify-center bg-gradient-to-br from-fiddo-blue via-fiddo-turquoise to-fiddo-orange p-4">
       <div className="w-full max-w-md space-y-8 rounded-xl bg-white p-8 shadow-lg">
         <div className="text-center">
-          <h1 className="text-4xl font-bold text-fiddo-blue">Fiddo</h1>
+          <Image src="/fiddo-logo.svg" alt="Fiddo" width={80} height={24} className="mx-auto" />
           <h2 className="mt-2 text-3xl font-bold tracking-tight text-gray-900">
             Crear una Cuenta
           </h2>
@@ -88,8 +90,6 @@ export default function RegisterPage() {
               <input id="password" name="password" type="password" required minLength={8} placeholder="••••••••" value={password} onChange={(e) => setPassword(e.target.value)} className="block w-full appearance-none rounded-md border border-gray-300 px-3 py-2 placeholder-gray-400 shadow-sm focus:border-fiddo-turquoise focus:outline-none focus:ring-fiddo-turquoise sm:text-sm" />
             </div>
           </div>
-          
-          {error && <p className="text-sm text-red-600">{error}</p>}
 
           <div>
             <button type="submit" disabled={isLoading} className="flex w-full justify-center rounded-md border border-transparent bg-fiddo-blue py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-fiddo-turquoise focus:outline-none focus:ring-2 focus:ring-fiddo-turquoise focus:ring-offset-2 disabled:opacity-50">


### PR DESCRIPTION
## Summary
- add Fiddo logo and brand colors to login and registration screens
- surface form feedback with toast pop-ups instead of inline messages
- show brand logo in dashboard header

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae0b5443c4832eb1f2fd1649d07c83